### PR TITLE
removed all dynamic memory allocation for the time being

### DIFF
--- a/qtclient/bitmap.cpp
+++ b/qtclient/bitmap.cpp
@@ -2,16 +2,12 @@
 
 BitMap::BitMap(quint8 width, quint8 height) : width(width), height(height), length(width*height)
 {
-    if(length > 0)
-        map = new bool[length];
-    else
-        map = nullptr;
+
 }
 
 BitMap::~BitMap()
 {
-    if(length > 0)
-        delete[] map;
+
 }
 
 void BitMap::set_bit(quint8 x, quint8 y, bool value)

--- a/qtclient/bitmap.h
+++ b/qtclient/bitmap.h
@@ -13,7 +13,7 @@ public:
     bool& operator[](quint16 i);
 
 private:
-    bool* map;
+    bool map[54];
     quint8 width;
     quint8 height;
     quint16 length;

--- a/qtclient/qtclient.h
+++ b/qtclient/qtclient.h
@@ -18,8 +18,8 @@ class QtClient : public QMainWindow
 
 public:
     QtClient(QWidget *parent = nullptr,
-             quint16 master_tcp_port = 0,
-             quint16 local_udp_port = 0);
+             quint16 tcp_port_to_master = 0,
+             quint16 udp_port_from_master = 0);
     ~QtClient();
 
     void emit_finished();
@@ -27,8 +27,8 @@ public:
 
 private:
     Ui::QtClient *ui;
-    quint16 master_tcp_port;
-    quint16 local_udp_port;
+    quint16 tcp_port_to_master;
+    quint16 udp_port_from_master;
 
     QTcpSocket tcp_socket;
     QUdpSocket udp_socket;

--- a/qtclient/qtclient.pro.user
+++ b/qtclient/qtclient.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.10.2, 2019-11-20T19:03:10. -->
+<!-- Written by QtCreator 4.10.2, 2019-11-21T11:46:20. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -306,8 +306,8 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qtclient</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:C:/Users/Jarno Poikonen/Desktop/qt-client/qtclient/qtclient.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">qtclient2</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:C:/Users/Jarno Poikonen/Desktop/VarastoRobo/qtclient/qtclient.pro</value>
     <value type="QString" key="RunConfiguration.Arguments"></value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>

--- a/qtclient/systembroadcastmessage.cpp
+++ b/qtclient/systembroadcastmessage.cpp
@@ -7,15 +7,7 @@ SystemBroadcastMessage::SystemBroadcastMessage()
 
 SystemBroadcastMessage::~SystemBroadcastMessage()
 {
-    if(obstacle_count > 0)
-    {
-        delete[] obstacle_list;
-    }
 
-    if(device_count > 0)
-    {
-        delete[] device_list;
-    }
 }
 
 void SystemBroadcastMessage::parse_datagram_string(char* datagram_string, qint64 datagram_size)
@@ -38,16 +30,11 @@ void SystemBroadcastMessage::parse_datagram_string(char* datagram_string, qint64
     else
         qDebug() << "BAD BITMAP LENGTH! \n";
 
-    if(obstacle_count > 0)
-        obstacle_list = new Point[obstacle_count];
-    else
+    if(obstacle_count == 0)
         qDebug() << "BAD OBSTACLE COUNT! \n";
 
-    if(device_count > 0)
-        device_list = new VarastoRoboDevice[device_count];
-//    else
-//        qDebug() << "BAD DEVICE COUNT! \n";
-
+    if(device_count == 0)
+        qDebug() << "BAD DEVICE COUNT! \n";
 
     QString map_str;
     for(quint8 i = 0; i < map_length; ++i)
@@ -83,8 +70,6 @@ void SystemBroadcastMessage::parse_datagram_string(char* datagram_string, qint64
         device_list[i] = VarastoRoboDevice(type, id, Point(x, y), ipv4_address);
         devices_str += device_list[i].str;
     }
-
-
 
     // save parsed datagram as a string for gui use
     str =   QString("datagram_size: ")     + QString::number(datagram_size)  + QString("\n") +

--- a/qtclient/systembroadcastmessage.h
+++ b/qtclient/systembroadcastmessage.h
@@ -29,8 +29,8 @@ private:
     quint8 device_count;    // 4x GoPiGo, UR5, Drone, QtClient = 7 (master not included here)
 
     BitMap warehouse_bitmap; // (0, 0), (1, 0) .. (8, 0), (0, 1) [54]
-    Point* obstacle_list;    // x, y // 1, 1 [54*2]
-    VarastoRoboDevice* device_list;     // type, id, x, y, ipv4 // 1, 1, 1, 1, 4 bytes [7*8]
+    Point obstacle_list[54];    // x, y // 1, 1 [54*2]
+    VarastoRoboDevice device_list[32];     // type, id, x, y, ipv4 // 1, 1, 1, 1, 4 bytes [7*8]
 };
 
 #endif // SYSTEMBROADCASTMESSAGE_H


### PR DESCRIPTION
Realized dynamic memory allocation was not properly accounted for and causes crashes on client when master send new data regarding new devices on the network.

Currently the code does not expect the device count go over 32. 
(master server is configured to assume the same 32)

Bitmap size does not exceed 54. (width 9, height 6)
Obstacle count does not exceed 54.